### PR TITLE
feat: add request ID middleware to generated project templates

### DIFF
--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -172,6 +172,7 @@ if [[ "$PLATFORM" == "cloudflare" ]]; then
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
+import { requestId } from 'hono/request-id';
 import { secureHeaders } from 'hono/secure-headers';
 
 type Bindings = {
@@ -187,9 +188,14 @@ const app = new Hono<{ Bindings: Bindings }>();
 app.use('*', logger());
 app.use('*', cors());
 app.use('*', secureHeaders());
+app.use('*', requestId());
 
 app.get('/health', (c) => {
-  return c.json({ status: 'ok', timestamp: new Date().toISOString() });
+  return c.json({
+    status: 'ok',
+    requestId: c.get('requestId'),
+    timestamp: new Date().toISOString(),
+  });
 });
 
 app.get('/', (c) => {
@@ -203,6 +209,7 @@ else
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
+import { requestId } from 'hono/request-id';
 import { secureHeaders } from 'hono/secure-headers';
 import { serve } from '@hono/node-server';
 
@@ -211,9 +218,14 @@ const app = new Hono();
 app.use('*', logger());
 app.use('*', cors());
 app.use('*', secureHeaders());
+app.use('*', requestId());
 
 app.get('/health', (c) => {
-  return c.json({ status: 'ok', timestamp: new Date().toISOString() });
+  return c.json({
+    status: 'ok',
+    requestId: c.get('requestId'),
+    timestamp: new Date().toISOString(),
+  });
 });
 
 app.get('/', (c) => {
@@ -297,16 +309,36 @@ TSEOF
 write_file "$API_DIR/tests/unit/health.test.ts" << 'HTEOF'
 import { describe, it, expect } from 'vitest';
 import { Hono } from 'hono';
+import { requestId } from 'hono/request-id';
 
 describe('Health endpoint', () => {
   const app = new Hono();
-  app.get('/health', (c) => c.json({ status: 'ok' }));
+  app.use('*', requestId());
+  app.get('/health', (c) =>
+    c.json({
+      status: 'ok',
+      requestId: c.get('requestId'),
+    }),
+  );
 
   it('should return ok status', async () => {
     const res = await app.request('/health');
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe('ok');
+  });
+
+  it('should return a requestId', async () => {
+    const res = await app.request('/health');
+    const body = await res.json();
+    expect(body.requestId).toBeDefined();
+    expect(typeof body.requestId).toBe('string');
+    expect(body.requestId.length).toBeGreaterThan(0);
+  });
+
+  it('should include X-Request-Id response header', async () => {
+    const res = await app.request('/health');
+    expect(res.headers.get('X-Request-Id')).toBeDefined();
   });
 });
 HTEOF

--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -338,7 +338,7 @@ describe('Health endpoint', () => {
 
   it('should include X-Request-Id response header', async () => {
     const res = await app.request('/health');
-    expect(res.headers.get('X-Request-Id')).toBeDefined();
+    expect(res.headers.get('X-Request-Id')).not.toBeNull();
   });
 });
 HTEOF


### PR DESCRIPTION
## Summary
- Add Hono's built-in `requestId()` middleware to both Cloudflare Workers and Node.js index.ts templates in `setup-project.sh`
- Health endpoint now returns `requestId` field; `X-Request-Id` header included on all responses automatically
- Health test updated with 3 test cases: status check, requestId in body, and X-Request-Id header presence

## Test plan
- [x] `bash -n scripts/setup-project.sh` — shell syntax clean
- [x] `./scripts/setup-project.sh test-cf --cloudflare --dry-run` — completes successfully
- [x] `./scripts/setup-project.sh test-node --node --dry-run` — completes successfully
- [ ] Generate a real project and run `pnpm test` to verify health tests pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)