### PR TITLE
feat: add VS Code workspace recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,11 @@ dist
 # TernJS port file
 .tern-port
 
+# VS Code — track shared settings and recommendations, ignore personal files
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "vitest.explorer",
+    "redhat.vscode-yaml",
+    "timonwong.shellcheck",
+    "EditorConfig.EditorConfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "vitest.configSearchPatternExclude": "{**/node_modules/**,**/vendor/**,**/.*/**,**/*.d.ts,**/templates/**}"
+}


### PR DESCRIPTION
## Summary
- Adds `.vscode/extensions.json` with 6 recommended extensions: ESLint, Prettier, Vitest, YAML, ShellCheck, and EditorConfig
- Tracks `.vscode/settings.json` (existing Vitest config exclusion pattern)
- Updates `.gitignore` to share `settings.json` and `extensions.json` while ignoring personal VS Code files (e.g., `launch.json`)

Closes #11

## Test plan
- [ ] Open the repo in VS Code and verify the "Recommended Extensions" prompt appears
- [ ] Confirm `launch.json` or other personal VS Code files are not tracked by git
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)