### PR TITLE
feat: add response compression middleware to project templates

### DIFF
--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -174,6 +174,8 @@ import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { requestId } from 'hono/request-id';
 import { secureHeaders } from 'hono/secure-headers';
+// Note: Response compression is handled automatically by Cloudflare's edge network.
+// No compress() middleware is needed for Workers deployments.
 
 type Bindings = {
   DB: D1Database;
@@ -207,6 +209,7 @@ SRCEOF
 else
   write_file "$API_DIR/src/index.ts" << 'SRCEOF'
 import { Hono } from 'hono';
+import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { requestId } from 'hono/request-id';
@@ -217,6 +220,7 @@ const app = new Hono();
 
 app.use('*', logger());
 app.use('*', cors());
+app.use('*', compress());
 app.use('*', secureHeaders());
 app.use('*', requestId());
 


### PR DESCRIPTION
## Summary
- Added Hono's `compress()` middleware to the Node.js template in `setup-project.sh` for automatic gzip/brotli response compression
- Added a comment to the Cloudflare Workers template explaining that compression is handled automatically at the edge
- No additional dependencies needed — `compress()` is built into Hono

## Test plan
- [x] `bash -n scripts/setup-project.sh` passes (script syntax valid)
- [x] Dry-run with `--node` completes successfully
- [x] Dry-run with `--cloudflare` completes successfully
- [ ] CI passes (ShellCheck + syntax validation)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)