### PR TITLE
feat: add graceful shutdown handling to Node.js template

### DIFF
--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -239,7 +239,35 @@ app.get('/', (c) => {
 const port = Number(process.env.PORT) || 3000;
 console.log(`Server starting on port ${port}`);
 
-serve({ fetch: app.fetch, port });
+const server = serve({ fetch: app.fetch, port });
+
+// --- Graceful shutdown ---
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+let isShuttingDown = false;
+
+const shutdown = (signal: string) => {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  console.log(`\n${signal} received. Shutting down gracefully...`);
+
+  const forceExit = setTimeout(() => {
+    console.error(`Forced shutdown after ${SHUTDOWN_TIMEOUT_MS / 1000}s timeout.`);
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  forceExit.unref();
+
+  server.close(() => {
+    console.log('HTTP server closed.');
+    // TODO: Close database connection pool when configured
+    // await pool.end();
+    console.log('Shutdown complete.');
+    process.exit(0);
+  });
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
 SRCEOF
   run_cmd pnpm add @hono/node-server
 fi


### PR DESCRIPTION
## Summary
- Adds SIGTERM/SIGINT signal handlers to the Node.js server template in `setup-project.sh`
- On signal, the server stops accepting new connections, drains in-flight requests, and exits cleanly
- Includes a 10-second force-exit timeout to prevent stalled shutdowns in production
- Duplicate signal guard prevents double-shutdown race conditions
- Placeholder included for database connection pool cleanup

## Test plan
- [ ] Run `./scripts/setup-project.sh test-app --node` and verify the generated `src/index.ts` contains the shutdown handlers
- [ ] Start the generated server with `pnpm dev`, send `SIGTERM` (e.g. `kill <pid>`), and confirm clean shutdown logs
- [ ] Send `SIGINT` (Ctrl+C) and confirm clean shutdown logs
- [ ] Verify Cloudflare Workers template (`--cloudflare`) is unchanged
- [ ] CI passes (shell syntax check + ShellCheck)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)