### PR TITLE
feat: add CI matrix testing for Node.js 20 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,29 @@ jobs:
           echo "$errors template validation failures"
           exit $errors
 
+  node-compat:
+    name: Node.js ${{ matrix.node-version }} Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: corepack enable
+      - run: pnpm install
+
+      - name: Verify installation
+        run: |
+          echo "Node.js version: $(node --version)"
+          echo "pnpm version: $(pnpm --version)"
+          pnpm ls --depth 0
+
   check-links:
     name: Check Markdown Links
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `node-compat` matrix job to CI that tests against Node.js 20 (LTS) and 22 (current LTS)
- Uses `corepack enable` for pnpm installation on both versions
- Verifies `pnpm install` succeeds and prints version info for debugging

Closes #16

## Test plan

- [ ] CI runs two matrix entries: Node.js 20 and Node.js 22
- [ ] Both entries install dependencies via corepack + pnpm
- [ ] Both matrix entries pass for CI to be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)