### PR TITLE
fix: exclude all contributor-covenant.org URLs from link checker

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -27,8 +27,8 @@ exclude = [
   "https://www.patreon.com/.*",
   # Shield badge images (always valid if the URL format is correct)
   "https://img.shields.io/.*",
-  # Contributor Covenant version-specific URLs may redirect
-  "https://www.contributor-covenant.org/version/.*",
+  # Contributor Covenant — blocks/resets automated requests
+  "https://www.contributor-covenant.org/.*",
   # Example/placeholder URLs
   "https://example.com.*"
 ]


### PR DESCRIPTION
The /translations endpoint intermittently resets connections in CI, causing flaky failures. The version-specific exclusion was already in place; this broadens it to the entire domain.

## Description

<!-- Describe your changes in detail -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g. Closes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Chore (dependency updates, CI changes, refactoring)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Tests pass (`./scripts/run-tests.sh`)
- [ ] Types check (`./scripts/check-types.sh`)
- [ ] Security scan passes (`./scripts/security-scan.sh`)
- [ ] Documentation updated (if applicable)
