### PR TITLE
feat: add ETag support middleware to templates

### DIFF
--- a/scripts/setup-project.sh
+++ b/scripts/setup-project.sh
@@ -171,6 +171,7 @@ if [[ "$PLATFORM" == "cloudflare" ]]; then
   write_file "$API_DIR/src/index.ts" << 'SRCEOF'
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { etag } from 'hono/etag';
 import { logger } from 'hono/logger';
 import { requestId } from 'hono/request-id';
 import { secureHeaders } from 'hono/secure-headers';
@@ -189,6 +190,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use('*', logger());
 app.use('*', cors());
+app.use('*', etag());
 app.use('*', secureHeaders());
 app.use('*', requestId());
 
@@ -211,6 +213,7 @@ else
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
+import { etag } from 'hono/etag';
 import { logger } from 'hono/logger';
 import { requestId } from 'hono/request-id';
 import { secureHeaders } from 'hono/secure-headers';
@@ -221,6 +224,7 @@ const app = new Hono();
 app.use('*', logger());
 app.use('*', cors());
 app.use('*', compress());
+app.use('*', etag());
 app.use('*', secureHeaders());
 app.use('*', requestId());
 


### PR DESCRIPTION
## Summary
- Adds Hono's built-in `etag()` middleware to both Cloudflare Workers and Node.js project templates in `setup-project.sh`
- Enables automatic HTTP caching via ETag headers for conditional requests out of the box
- Import from `hono/etag`, applied before route handlers in both templates

## Test plan
- [ ] Run `bash -n scripts/setup-project.sh` — syntax check passes
- [ ] Run `./scripts/setup-project.sh test-cf --cloudflare --dry-run` — verify etag import and middleware in output
- [ ] Run `./scripts/setup-project.sh test-node --node --dry-run` — verify etag import and middleware in output
- [ ] CI passes (ShellCheck, syntax validation)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)