### PR TITLE
chore(deps): pin fast-uri override for security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
   "author": "PAMulligan",
   "license": "MIT",
   "packageManager": "pnpm@10.15.1",
+  "pnpm": {
+    "overrides": {
+      "fast-uri@<=3.1.0": ">=3.1.1",
+      "fast-uri@<=3.1.1": ">=3.1.2"
+    }
+  },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri@<=3.1.0: '>=3.1.1'
+  fast-uri@<=3.1.1: '>=3.1.2'
+
 importers:
 
   .:
@@ -380,8 +384,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
@@ -1112,7 +1116,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1370,7 +1374,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.1.4:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` for fast-uri to `package.json`, matching the security advisory versions Dependabot's audit-fix was injecting into PR lockfiles.
- Regenerates `pnpm-lock.yaml` so the declared overrides and locked overrides agree.

## Why

Dependabot's recent group-update PRs (e.g. #90) include a `(via audit fix)` step that adds `fast-uri@<=3.1.0: '>=3.1.1'` and `fast-uri@<=3.1.1: '>=3.1.2'` to the lockfile. Those overrides weren't declared in `package.json` on `main`, so pnpm 10's frozen-lockfile install fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Declaring the overrides here applies the security patch repo-wide and unblocks any future PR that touches the lockfile.

## Test plan

- [x] `pnpm install` regenerates `pnpm-lock.yaml` with the matching `overrides:` block
- [x] `pnpm install --frozen-lockfile` passes locally (no mismatch)
- [ ] CI Node 20 + Node 22 compatibility jobs pass
- [ ] After merge, rebase #90 — `Check Markdown Links` and `Node.js 20 Compatibility` should both go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)