### PR TITLE
ci(stale): exempt pinned items and document required labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
+          # The stale and pinned labels must exist in the repo's label set
+          # (gh label create); deleting them breaks filtering and exemptions.
+
           # Issue configuration
           days-before-issue-stale: 60
           days-before-issue-close: 14
@@ -25,12 +28,13 @@ jobs:
             not had any activity in the last 60 days. It will be closed in
             14 days if no further activity occurs. If this issue is still
             relevant, please leave a comment or remove the stale label.
-            Thank you for your contributions!
+            Maintainers can add the pinned label to exempt an issue from
+            being auto-closed. Thank you for your contributions!
           close-issue-message: >
             This issue has been automatically closed due to inactivity.
             If you believe this issue is still relevant, please feel free
             to reopen it with updated context. Thank you!
-          exempt-issue-labels: "priority: high,help wanted"
+          exempt-issue-labels: "priority: high,help wanted,pinned"
 
           # PR configuration
           days-before-pr-stale: 30
@@ -46,3 +50,4 @@ jobs:
             This pull request has been automatically closed due to
             inactivity. If you would like to continue this work, please
             feel free to reopen it or create a new pull request. Thank you!
+          exempt-pr-labels: "pinned"


### PR DESCRIPTION
## Summary
- Recreated the `stale` label (and added a new `pinned` label) in the repo's label registry via `gh label create`, so the label referenced by `stale.yml` resolves and stale items can be found with a `label:stale` filter again
- Added `pinned` to `exempt-issue-labels` and introduced `exempt-pr-labels: "pinned"` so intentionally long-lived issues and PRs are never auto-closed (PRs previously had no exemption mechanism at all)
- The stale-issue message now mentions the permanent rescue path, and a comment in the workflow documents that both labels must exist in the repo's label set

## Verification
- `gh label list` shows both labels with descriptions and colors (`stale` #ededed, `pinned` #5319e7)
- `gh issue list --label stale` and `--label pinned` exit 0 — the filters resolve again (0 items currently marked)
- `stale.yml` parses as valid YAML (checked with js-yaml)

## Notes for reviewers
- 18 open issues (#22-26, #28-29, #32-42) are past the 60-day inactivity threshold with no exempt label; the next scheduled run (Monday 00:00 UTC) will mark them stale unless they are pinned first
- Issue #58 is active again but carries no exempt label, so it is a candidate for `pinned`

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)