### PR TITLE
feat: add all-contributors recognition system

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,31 @@
+{
+  "projectName": "Nerva",
+  "projectOwner": "PMDevSolutions",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 7,
+  "linkToUsage": false,
+  "skipCi": false,
+  "contributors": [
+    {
+      "login": "PAMulligan",
+      "name": "PMullz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13412531?v=4",
+      "profile": "https://pmds.info/",
+      "contributions": [
+        "code",
+        "doc",
+        "test",
+        "infra",
+        "review",
+        "ideas"
+      ]
+    }
+  ]
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit ${1}
+npx --no -- commitlint --edit "${1}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,34 @@ Community members are encouraged to vote on priorities and propose new ideas via
 
 ---
 
+## Contributor Recognition
+
+Nerva follows the [All Contributors](https://allcontributors.org) specification: every kind of contribution counts, not just code. Recognized contributors appear in the [contributors table](README.md#contributors) in the README.
+
+The contribution types most relevant to Nerva:
+
+| Type | Emoji | Covers |
+|------|-------|--------|
+| `code` | 💻 | Code contributions |
+| `doc` | 📖 | Documentation |
+| `test` | ⚠️ | Tests |
+| `bug` | 🐛 | Bug reports |
+| `ideas` | 🤔 | Ideas and suggestions |
+| `review` | 👀 | Code review |
+| `infra` | 🚇 | Infrastructure (CI/CD, deployment) |
+
+Other [emoji key](https://allcontributors.org/en/reference/emoji-key/) types count as well.
+
+**How recognition works:** once your contribution lands, a maintainer comments on the related issue or pull request:
+
+```text
+@all-contributors please add @<your-username> for code, doc
+```
+
+The [@all-contributors bot](https://allcontributors.org/en/bot/usage/) then opens a pull request adding you to the README table and `.all-contributorsrc`. If your contribution was overlooked, mention it on your PR or open an issue — recognition requests are always welcome.
+
+---
+
 ## Code of Conduct
 
 This project follows the [Contributor Covenant v2.1](CODE_OF_CONDUCT.md). All contributors are expected to:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Claude Code-integrated API & backend development framework with TypeScript, Ho
 [![CI](https://github.com/PMDevSolutions/Nerva/actions/workflows/ci.yml/badge.svg)](https://github.com/PMDevSolutions/Nerva/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Patreon](https://img.shields.io/badge/Patreon-Support-orange?logo=patreon)](https://www.patreon.com/PaulMakesThings)
+[![All Contributors](https://img.shields.io/github/all-contributors/PMDevSolutions/Nerva?color=ee8449&style=flat-square)](#contributors)
 
 ---
 
@@ -206,6 +207,28 @@ Nerva is the backend counterpart in a family of Claude Code-integrated developme
 Contributions are welcome! Please read the [Contributing Guide](CONTRIBUTING.md) before submitting a pull request.
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Contributors
+
+Thanks to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://pmds.info/"><img src="https://avatars.githubusercontent.com/u/13412531?v=4?s=100" width="100px;" alt="PMullz"/><br /><sub><b>PMullz</b></sub></a><br /><a href="https://github.com/PMDevSolutions/Nerva/commits?author=PAMulligan" title="Code">💻</a> <a href="https://github.com/PMDevSolutions/Nerva/commits?author=PAMulligan" title="Documentation">📖</a> <a href="https://github.com/PMDevSolutions/Nerva/commits?author=PAMulligan" title="Tests">⚠️</a> <a href="#infra-PAMulligan" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="https://github.com/PMDevSolutions/Nerva/pulls?q=is%3Apr+reviewed-by%3APAMulligan" title="Reviewed Pull Requests">👀</a> <a href="#ideas-PAMulligan" title="Ideas, Planning, & Feedback">🤔</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind are welcome — see [how contributors are recognized](CONTRIBUTING.md#contributor-recognition).
 
 ## Support the Project
 


### PR DESCRIPTION
## Summary
- Adds `.all-contributorsrc` configured for the All Contributors spec: `commitConvention: "angular"` so bot commits pass commitlint, `skipCi: false` so CI runs on bot PRs, contributor table written to `README.md`
- README gains an all-contributors badge and a `## Contributors` section with the generated table, seeded with the maintainer (`PAMulligan`: code, doc, test, infra, review, ideas)
- CONTRIBUTING gains a "Contributor Recognition" section documenting the seven contribution types relevant to Nerva (`code`, `doc`, `test`, `bug`, `ideas`, `review`, `infra`) and the @all-contributors bot comment workflow
- Fixes `.husky/commit-msg` to quote the commit-message file path - the unquoted `${1}` breaks commitlint for any clone or linked worktree under a path containing spaces (discovered while committing this change)

## One manual step required
The @all-contributors GitHub App is not yet installed on PMDevSolutions (org installations checked: it is absent). Install it once at https://github.com/apps/allcontributors and grant it this repository - after that, commenting `@all-contributors please add @user for code, doc` on any issue or PR makes the bot open an update PR automatically.

## Verification
- `.all-contributorsrc` parses as valid JSON
- Contributor table generated with `all-contributors-cli` (identical output to what the bot produces)
- All new outbound links return 200, including the lychee-checked avatar URL and the https://pmds.info/ profile link

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)